### PR TITLE
chore: ignore private assets and Zone.Identifier junk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Local-only media / private assets (do not commit)
+assets/
+
+# Windows download metadata junk
+*:Zone.Identifier
+*.Zone.Identifier


### PR DESCRIPTION
## Summary
- Adds a root `.gitignore` so local media under `assets/` stays private and never gets committed.
- Also ignores Windows `Zone.Identifier` download metadata files so they cannot reappear as project noise.

## Zone.Identifier cleanup
- Deleted local file: `ChatGPT Image Jul 31, 2026, 11_44_53 PM.png:Zone.Identifier`
- Confirmed it was **never tracked** in git history (`git ls-files` / history search: none)
- Confirmed it is **gone from the working tree** (`find` for `*Zone.Identifier*`: 0 hits)
- `.gitignore` blocks `*:Zone.Identifier` and `*.Zone.Identifier` going forward

## What is intentionally NOT in this PR
- No video or other media files.
- The trailer remains local-only at `assets/hermes-skins-pack-trailer.mp4` and is ignored by the new rule.

## Verification
- `git check-ignore -v assets/ assets/hermes-skins-pack-trailer.mp4` matched `.gitignore:2:assets/`
- Staged/committed diff is only `.gitignore`
- Pre-commit secret scan passed on commit
- Working tree has no Zone.Identifier files
- `git status` does not list `assets/` or the trailer (only ignored `assets/`)

## Approval boundary
- Review and merge when ready. I will not merge.
